### PR TITLE
Request gui tweak

### DIFF
--- a/src/main/kotlin/badasintended/slotlink/screen/RequestScreenHandler.kt
+++ b/src/main/kotlin/badasintended/slotlink/screen/RequestScreenHandler.kt
@@ -219,10 +219,11 @@ open class RequestScreenHandler(
                         }
                         else -> if (!variant.isBlank) Transaction.openOuter().use { transaction ->
                             val max = min(view.count.toLong(), variant.item.maxCount.toLong())
+                            val request = if (data == 1) (max + 1) / 2 else max
                             var extracted = 0L
                             for (storage in storages) {
-                                extracted += storage.extract(variant, max - extracted, transaction)
-                                if (extracted == max) break
+                                extracted += storage.extract(variant, request - extracted, transaction)
+                                if (extracted == request) break
                             }
                             cursorStorage.insert(variant, extracted, transaction)
                             cursor = cursorStorage.resource.toStack(cursorStorage.amount.toInt())

--- a/src/main/kotlin/badasintended/slotlink/screen/RequestScreenHandler.kt
+++ b/src/main/kotlin/badasintended/slotlink/screen/RequestScreenHandler.kt
@@ -218,7 +218,7 @@ open class RequestScreenHandler(
                             transaction.commit()
                         }
                         else -> if (!variant.isBlank) Transaction.openOuter().use { transaction ->
-                            val max = variant.item.maxCount.toLong()
+                            val max = min(view.count.toLong(), variant.item.maxCount.toLong())
                             var extracted = 0L
                             for (storage in storages) {
                                 extracted += storage.extract(variant, max - extracted, transaction)


### PR DESCRIPTION
Slight changes to how one can extract items from the storage request:
* Do not try to extract more than what is shown. This avoids some unexpected behaviors with unregular storages.
* Using the right mouse button allows to pick up half of the available items, up to half a stack. This is consistent with regular containers (and I miss this a lot).